### PR TITLE
fix(gatekeeper): update deployment steps for constraint templates

### DIFF
--- a/workshop/foundation/README.md
+++ b/workshop/foundation/README.md
@@ -196,7 +196,7 @@ kubectl get pods -n gatekeeper-system
 
 ### Step 3: Deploy Constraint Template
 
-Deploy a simple constraint template (Use the apprpriate relative or absolute paths for the yaml file)
+Deploy a simple constraint template (Use the appropriate relative or absolute paths for the YAML file)
 `kubectl apply -f simple-constraint-template.yaml`
 
 ``` yaml


### PR DESCRIPTION
Resolves #6 

This pull request updates the `workshop/foundation/README.md` to clarify and reorganize the steps for deploying Gatekeeper constraint templates and constraints. The changes improve the instructional flow and make deployment steps more explicit.

Gatekeeper deployment steps:

* Changed the section previously titled "Verify gatekeeper install worked" to "Step 5: Test the Constraint"
* Added a new section "Step 3: Deploy Constraint"
* Added a new section "Step 4: Deploy Constraint"

Formatting and cleanup:

* Removed extra blank lines after the example for creating a namespace with the required label, improving readability.