### PR TITLE
fix(readme): remove gatekeeper-policy-manager from verification output

### DIFF
--- a/workshop/foundation/README.md
+++ b/workshop/foundation/README.md
@@ -191,7 +191,6 @@ kubectl get pods -n gatekeeper-system
 # NAME                                             READY   STATUS    RESTARTS   AGE
 # gatekeeper-audit-xxx                             1/1     Running   0          1m
 # gatekeeper-controller-manager-xxx                1/1     Running   0          1m
-# gatekeeper-policy-manager-xxx                    1/1     Running   0          1m
 ```
 
 ### Verify gatekeeper install worked.
@@ -298,7 +297,6 @@ kubectl get pods -n gatekeeper-system
 # Expected output (all should be Running):
 # gatekeeper-audit-xxx                 1/1     Running   0          2m
 # gatekeeper-controller-manager-xxx    1/1     Running   0          2m
-# gatekeeper-policy-manager-xxx        1/1     Running   0          2m
 
 # Verify constraint template is working
 kubectl get constrainttemplates


### PR DESCRIPTION
Resolves #8 

Removes mention of `gatekeeper-policy-manager` pod, which is not part of the lab Grafana install. 