### PR TITLE
Change CVE template example output

### DIFF
--- a/workshop/capoc/cve/readme.md
+++ b/workshop/capoc/cve/readme.md
@@ -71,7 +71,7 @@ kubectl get constrainttemplates
 # Example output:
 # NAME                    AGE
 # k8srequiredlabels      10m
-# k8scvescanning         1m
+# vulnerabilityscan   56s
 ```
 
 **What this template does**:


### PR DESCRIPTION
Updated the CVE template example output in the readme. The Constraint-Template Name has changed.