### PR TITLE
Revise CVE constraint example output

### DIFF
--- a/workshop/capoc/cve/readme.md
+++ b/workshop/capoc/cve/readme.md
@@ -96,9 +96,8 @@ kubectl get constraints
 
 # Look for your CVE constraint
 # Example output:
-# NAME                           AGE
-# ns-must-have-gk               15m
-# container-cve-scanning        2m
+# NAME
+# vulnerabilityscan.constraints.gatekeeper.sh/enforce-vulnerability-scanning
 ```
 
 **Understanding the constraint configuration**:


### PR DESCRIPTION
Updated example output for CVE constraint in readme. The constraint-name is now different due to changed constraint name in the files.