### PR TITLE
Fix command syntax for describing constraints

### DIFF
--- a/workshop/capoc/cve/readme.md
+++ b/workshop/capoc/cve/readme.md
@@ -185,7 +185,7 @@ kubectl get constrainttemplates | grep -i vuln
 kubectl get constraints | grep -i vuln
 
 # Check constraint status for any issues
-kubectl describe constraint -f cve-constraint.yaml
+kubectl describe -f cve-constraint.yaml
 ```
 
 **2. Policy Enforcement Test**:


### PR DESCRIPTION
if you try the old syntax (kubectl describe constraint -f cve-constraint.yaml) you get: error: when paths, URLs, or stdin is provided as input, you may not specify resource arguments as well