### PR TITLE
Update ingress class definition in deployment.yaml

### DIFF
--- a/workshop/teams-management/teams-api/deployment.yaml
+++ b/workshop/teams-management/teams-api/deployment.yaml
@@ -87,8 +87,8 @@ metadata:
     traefik.ingress.kubernetes.io/headers.accesscontrolallowmethods: GET,POST,PUT,DELETE,OPTIONS
     traefik.ingress.kubernetes.io/headers.accesscontrolalloworigin: "*"
     traefik.ingress.kubernetes.io/headers.accesscontrolallowheaders: Content-Type,Authorization,X-Requested-With
-    kubernetes.io/ingress.class: traefik
 spec:
+  ingressClassName: traefik
   rules:
   - host: teams-api.127.0.0.1.sslip.io
     http:


### PR DESCRIPTION
Annotation of kubernetes.io/ingress.class is deprecated, now using ingressClass in spec.